### PR TITLE
Add 'calc' support and 'style'-related props.

### DIFF
--- a/src/Pane.tsx
+++ b/src/Pane.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  CSSProperties,
   PropsWithChildren,
   createElement,
   isValidElement,
@@ -16,9 +17,12 @@ export interface PaneProps extends PropsWithChildren {
   splitter?: 'left' | 'right';
   splitterWidth?: number;
   splitterColor?: string;
+  splitterStyles?: CSSProperties;
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
+  styles?: CSSProperties;
 }
 
 const Pane = ({ children }: PaneProps) => children;
@@ -34,6 +38,8 @@ export interface InnerPaneProps {
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
+  styles?: CSSProperties;
 }
 
 export const InnerPane = ({
@@ -44,6 +50,8 @@ export const InnerPane = ({
   bgColor,
   borderWidth,
   borderColor,
+  borderStyles,
+  styles,
   children: _children
 }: PropsWithChildren<InnerPaneProps>) => {
   const children = useMemo(() => {
@@ -84,7 +92,8 @@ export const InnerPane = ({
           position: 'absolute',
           height: '100%',
           backgroundColor: bgColor,
-          overflow: 'hidden'
+          overflow: 'hidden',
+          ...styles
         }}
       >
         {/* Border on the right side of the pane */}
@@ -96,7 +105,8 @@ export const InnerPane = ({
               right: 0,
               width: `${borderWidth}px`,
               height: '100%',
-              backgroundColor: borderColor
+              backgroundColor: borderColor,
+              ...borderStyles
             }}
           />
         )}

--- a/src/PaneRow.tsx
+++ b/src/PaneRow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  CSSProperties,
   Children,
   PropsWithChildren,
   ReactElement,
@@ -24,10 +25,13 @@ export interface PaneRowProps extends PropsWithChildren {
   splitter?: 'top' | 'bottom';
   splitterHeight?: number;
   splitterColor?: string;
+  splitterStyles?: CSSProperties;
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
   gap?: number;
+  styles?: CSSProperties;
 }
 
 const PaneRow = ({ children }: PaneRowProps) => children;
@@ -45,7 +49,9 @@ export interface InnerPaneRowProps {
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
   gap: number;
+  styles?: CSSProperties;
 }
 
 export const InnerPaneRow = ({
@@ -57,7 +63,9 @@ export const InnerPaneRow = ({
   bgColor,
   borderWidth,
   borderColor,
+  borderStyles,
   gap,
+  styles = {},
   children
 }: PropsWithChildren<InnerPaneRowProps>) => {
   const ref = useRef<HTMLDivElement>(null);
@@ -139,7 +147,9 @@ export const InnerPaneRow = ({
           width: paneWidthPxs[index],
           bgColor: pane.props.bgColor ?? bgColor,
           borderWidth: pane.props.borderWidth ?? borderWidth,
-          borderColor: pane.props.borderColor ?? borderColor
+          borderColor: pane.props.borderColor ?? borderColor,
+          borderStyles: pane.props.borderStyles ?? borderStyles,
+          styles: pane.props.styles ?? styles
         },
         pane.props.children
       );
@@ -148,7 +158,16 @@ export const InnerPaneRow = ({
 
       return c;
     });
-  }, [panes, paneWidthPxs, bgColor, borderWidth, borderColor, gap]);
+  }, [
+    panes,
+    paneWidthPxs,
+    bgColor,
+    borderWidth,
+    borderColor,
+    borderStyles,
+    styles,
+    gap
+  ]);
 
   // Drag handler for the splitters.
   const onPaneSplitterDrag = useCallback(
@@ -209,6 +228,7 @@ export const InnerPaneRow = ({
         const sWidth = pane.props.splitterWidth ?? 4;
         const sHeight = height;
         const color = pane.props.splitterColor ?? 'rgba(0, 0, 0, 0.2)';
+        const styles = pane.props.splitterStyles ?? {};
         const boundMinX = rect.x;
         const boundMaxX = rect.x + paneWidthPxs[index];
         const boundMinY = y;
@@ -233,6 +253,7 @@ export const InnerPaneRow = ({
           width: sWidth,
           height: sHeight,
           color,
+          styles,
           bounds: {
             minX: boundMinX,
             minY: boundMinY,
@@ -262,7 +283,8 @@ export const InnerPaneRow = ({
         top: `${top}px`,
         height: `${height}px`,
         position: 'absolute',
-        width: '100%'
+        width: '100%',
+        ...styles
       }}
     >
       {/* Border on the bottom side of the row */}
@@ -275,7 +297,8 @@ export const InnerPaneRow = ({
             width: '100%',
             height: `${borderWidth}px`,
             backgroundColor: borderColor,
-            zIndex: 1
+            zIndex: 1,
+            ...borderStyles
           }}
         />
       )}

--- a/src/PaneSystem.tsx
+++ b/src/PaneSystem.tsx
@@ -12,7 +12,8 @@ import {
   createContext,
   useContext,
   Dispatch,
-  useRef
+  useRef,
+  CSSProperties
 } from 'react';
 import { PaneRowProps, InnerPaneRow } from './PaneRow';
 import { sizeToPixels, limit, createId } from './utils';
@@ -44,6 +45,7 @@ interface CorePaneSystemProps extends PropsWithChildren {
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
   gap?: number;
 }
 
@@ -61,6 +63,7 @@ const CorePaneSystem = ({
   bgColor = '#4b5563',
   borderWidth = 1,
   borderColor = '#909090',
+  borderStyles = {},
   gap = 0,
   children
 }: PropsWithChildren<CorePaneSystemProps>) => {
@@ -167,6 +170,8 @@ const CorePaneSystem = ({
           bgColor: row.props.bgColor ?? bgColor,
           borderWidth: row.props.borderWidth ?? borderWidth,
           borderColor: row.props.borderColor ?? borderColor,
+          borderStyles: row.props.borderStyles ?? borderStyles,
+          styles: row.props.styles,
           gap: row.props.gap ?? gap
         },
         row.props.children
@@ -184,6 +189,7 @@ const CorePaneSystem = ({
     bgColor,
     borderWidth,
     borderColor,
+    borderStyles,
     gap
   ]);
 
@@ -246,6 +252,7 @@ const CorePaneSystem = ({
         const sWidth = rect.width;
         const sHeight = row.props.splitterHeight ?? 4;
         const color = row.props.splitterColor ?? 'rgba(0, 0, 0, 0.2)';
+        const styles = row.props.splitterStyles ?? {};
         const boundMinX = x;
         const boundMaxX = x + sWidth;
         const boundMinY = rect.y;
@@ -270,6 +277,7 @@ const CorePaneSystem = ({
           width: sWidth,
           height: sHeight,
           color,
+          styles,
           bounds: {
             minX: boundMinX,
             minY: boundMinY,
@@ -316,6 +324,7 @@ interface PaneSystemProps extends PropsWithChildren {
   bgColor?: string;
   borderWidth?: number;
   borderColor?: string;
+  borderStyles?: CSSProperties;
   gap?: number;
 }
 

--- a/src/splitter/PaneRowSplitter.tsx
+++ b/src/splitter/PaneRowSplitter.tsx
@@ -83,7 +83,7 @@ const PaneRowSplitter = ({ splitter }: PaneRowSplitterProps) => {
   return (
     <div
       ref={ref}
-      className="splitter"
+      className="splitter splitter-vertical"
       style={{
         position: 'absolute',
         width,
@@ -94,7 +94,8 @@ const PaneRowSplitter = ({ splitter }: PaneRowSplitterProps) => {
         cursor: 'row-resize',
         zIndex: 10,
         transition: 'background-color 0.2s',
-        transform: `translateY(-${splitter.height / 2}px)`
+        transform: `translateY(-${splitter.height / 2}px)`,
+        ...splitter.styles
       }}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}

--- a/src/splitter/PaneSplitter.tsx
+++ b/src/splitter/PaneSplitter.tsx
@@ -83,7 +83,7 @@ const PaneSplitter = ({ splitter }: PaneSplitterProps) => {
   return (
     <div
       ref={ref}
-      className="splitter"
+      className="splitter splitter-horizontal"
       style={{
         position: 'absolute',
         width,
@@ -94,7 +94,8 @@ const PaneSplitter = ({ splitter }: PaneSplitterProps) => {
         cursor: 'col-resize',
         zIndex: 10,
         transition: 'background-color 0.2s',
-        transform: `translateX(-${splitter.width / 2}px)`
+        transform: `translateX(-${splitter.width / 2}px)`,
+        ...splitter.styles
       }}
       onPointerEnter={onPointerEnter}
       onPointerLeave={onPointerLeave}

--- a/src/splitter/SplitterRegistry.tsx
+++ b/src/splitter/SplitterRegistry.tsx
@@ -1,4 +1,5 @@
 import {
+  CSSProperties,
   PropsWithChildren,
   createContext,
   useCallback,
@@ -15,6 +16,7 @@ export type Splitter = {
   width: number;
   height: number;
   color: string;
+  styles: CSSProperties;
   bounds: {
     minX: number;
     minY: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,30 +1,6 @@
 import type { Component } from 'react';
 import type { PaneSystemComponentType } from './PaneSystem';
 
-// Convert size to pixels.
-export const sizeToPixels = (size: string | number, relativeTo?: number) => {
-  if (typeof size === 'number') return size;
-
-  const [number, unit] = size.split(/(\d+\.?\d*)/).filter(Boolean);
-
-  // If there's no unit, return the number as is.
-  if (!unit) return +number;
-
-  const parsedNumber = parseFloat(number);
-  const parsedUnit = unit.trim();
-
-  if (Number.isNaN(parsedNumber)) return 0;
-
-  switch (parsedUnit) {
-    case 'px':
-      return parsedNumber;
-    case '%':
-      return (relativeTo ?? 0) * (parsedNumber / 100);
-    default:
-      return 0;
-  }
-};
-
 // Limit the given number to the given range.
 export const limit = (number: number, min: number, max: number) => {
   return Math.min(Math.max(number, min), max);
@@ -52,4 +28,61 @@ export const createId = () => {
 // Check if the given values are approximately equal.
 export const isEqual = (a: number, b: number, epsilon = 1) => {
   return Math.abs(a - b) < epsilon;
+};
+
+// Convert size to pixels
+export const sizeToPixels = (size: string | number, relativeTo: number) => {
+  if (typeof size === 'number') return size;
+
+  // Remove 'calc(' and ')'
+  const exp = size.replace(/calc\(|\)/g, '').trim();
+  const parts = exp.split(/([+\-*/])/).map((p) => p.trim());
+
+  let r = 0;
+  let op = '+';
+
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i];
+
+    if (!p) continue;
+
+    // If it's an operator, store it
+    if (['+', '-', '*', '/'].includes(p)) {
+      op = p;
+      continue;
+    }
+
+    let v = 0;
+
+    // Handle each units
+    if (p.includes('%')) {
+      const percent = parseFloat(p);
+      v = (percent / 100) * relativeTo;
+    } else if (p.includes('px')) {
+      v = parseFloat(p);
+    } else {
+      v = parseFloat(p);
+    }
+
+    // Apply the operator
+    switch (op) {
+      case '+':
+        r += v;
+        break;
+
+      case '-':
+        r -= v;
+        break;
+
+      case '*':
+        r *= v;
+        break;
+
+      case '/':
+        r /= v;
+        break;
+    }
+  }
+
+  return r;
 };


### PR DESCRIPTION
- Can have 'calc()' in widths and heights.
- Added 'styles', 'borderStyles', and 'splitterStyles' to override the default values.